### PR TITLE
feat: [PubSub] add Google Pub/Sub Schema Revision support

### DIFF
--- a/src/Connection/ConnectionInterface.php
+++ b/src/Connection/ConnectionInterface.php
@@ -188,5 +188,20 @@ interface ConnectionInterface
     /**
      * @param array $args
      */
+    public function listRevisions(array $args);
+
+    /**
+     * @param array $args
+     */
+    public function commitSchema(array $args);
+
+    /**
+     * @param array $args
+     */
+    public function deleteRevision(array $args);
+
+    /**
+     * @param array $args
+     */
     public function validateMessage(array $args);
 }

--- a/src/Connection/Grpc.php
+++ b/src/Connection/Grpc.php
@@ -761,4 +761,48 @@ class Grpc implements ConnectionInterface
         $this->schemaClient = $this->constructGapic(SchemaServiceClient::class, $this->clientConfig);
         return $this->schemaClient;
     }
+
+    /**
+     * Retrieve schema revisions
+     *
+     * @param array $args
+     * @return array
+     */
+    public function listRevisions(array $args)
+    {
+        return $this->send([$this->getSchemaClient(), 'listSchemaRevisions'], [
+            $this->pluck('name', $args),
+            $args,
+        ]);
+    }
+
+    /**
+     * Create schema revisions
+     *
+     * @param array $args
+     * @return array
+     */
+    public function commitSchema(array $args)
+    {
+        return $this->send([$this->getSchemaClient(), 'commitSchema'], [
+            $this->pluck('name', $args),
+            new Schema($this->pluck('schema', $args)),
+            $args,
+        ]);
+    }
+
+    /**
+     * Delete schema revision
+     *
+     * @param array $args
+     * @return array
+     */
+    public function deleteRevision(array $args)
+    {
+        return $this->send([$this->getSchemaClient(), 'deleteSchemaRevision'], [
+            $this->pluck('name', $args),
+            null,
+            $args,
+        ]);
+    }
 }

--- a/src/Connection/Rest.php
+++ b/src/Connection/Rest.php
@@ -344,6 +344,30 @@ class Rest implements ConnectionInterface
     /**
      * @param array $args
      */
+    public function listRevisions(array $args)
+    {
+        return $this->send('schemas', 'listRevisions', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function commitSchema(array $args)
+    {
+        return $this->send('schemas', 'commit', $args);
+    }
+
+    /**
+     * @param array $args
+     */
+    public function deleteRevision(array $args)
+    {
+        return $this->send('schemas', 'deleteRevision', $args);
+    }
+
+    /**
+     * @param array $args
+     */
     public function validateMessage(array $args)
     {
         return $this->send('schemas', 'validateMessage', $args);

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -19,6 +19,7 @@ namespace Google\Cloud\PubSub;
 
 use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\PubSub\Connection\ConnectionInterface;
+use Google\Cloud\PubSub\V1\Schema\Type;
 
 /**
  * Represents a Pub/Sub Schema resource.
@@ -102,6 +103,80 @@ class Schema
         return $this->connection->deleteSchema([
             'name' => $this->name
         ] + $options);
+    }
+
+    /**
+     * Get list  schema revisions.
+     *
+     * Example:
+     * ```
+     * $revisions = $schema->listRevisions();
+     * foreach ($revisions['schemas'] as $revision) {
+     *     echo $revisions['definition'];
+     * }
+     * ```
+     * @see https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.schemas/listRevisions List revisions
+     * @param array $options [optional] Configuration Options
+     * @return array
+     */
+    public function listRevisions(array $options = [])
+    {
+        return $this->connection->listRevisions([
+                'name' => $this->name,
+            ] + $options);
+    }
+
+    /**
+     * Commit schema revision.
+     *
+     * Example:
+     * ```
+     * $definition = file_get_contents('my-schema.txt');
+     * $revision = $schema->commit($definition, 'AVRO);
+     *
+     * @see https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.schemas/commit Commit Schema revision.
+     * ```
+     *
+     * @param string $definition The definition of the schema. This should
+     *     contain a string representing the full definition of the schema that
+     *     is a valid schema definition of the type specified in `type`. See
+     *     [Schema](https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.schemas#Schema)
+     *     for details.
+     * @param string $type The schema type. Allowed values are `AVRO` and `PROTOCOL_BUFFER`.
+     * @param array $options [optional] Configuration options
+     * @return array revision created
+     */
+    public function commit($definition, $type, array $options = [])
+    {
+        return $this->connection->commitSchema([
+                'schema' => [
+                    'definition' => $definition,
+                    'type' => $type,
+                ],
+                'name' => $this->name
+            ] + $options);
+    }
+
+
+    /**
+     * Commit schema revision.
+     *
+     * Example:
+     * ```
+     * $definition = file_get_contents('my-schema.txt');
+     * $revision = $schema->commit($definition, 'AVRO);
+     *
+     * @see https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.schemas/deleteRevision Delete Schema revision.
+     * ```
+     *
+     * @param string $revisionId The revisionId
+     * @return array deleted revision
+     */
+    public function deleteRevision($revisionId)
+    {
+        return $this->connection->deleteRevision([
+            'name' => $this->name .'@' . $revisionId
+        ]);
     }
 
     /**

--- a/tests/Unit/Connection/RestTest.php
+++ b/tests/Unit/Connection/RestTest.php
@@ -128,6 +128,9 @@ class RestTest extends TestCase
             ['deleteSchema'],
             ['validateSchema'],
             ['validateMessage'],
+            ['listRevisions'],
+            ['commitSchema'],
+            ['deleteRevision'],
         ];
     }
 }

--- a/tests/Unit/SchemaTest.php
+++ b/tests/Unit/SchemaTest.php
@@ -116,4 +116,48 @@ class SchemaTest extends TestCase
 
         $this->assertFalse($this->schema->exists());
     }
+
+    public function testlistRevisions()
+    {
+        $this->connection
+            ->listRevisions(['name' => self::NAME,])
+            ->shouldBeCalledOnce()
+            ->willReturn(['foo' => 'bar']);
+
+        $this->schema->___setProperty('connection', $this->connection->reveal());
+
+        $this->assertEquals('bar', $this->schema->listRevisions()['foo']);
+    }
+
+    public function testCommit()
+    {
+        $this->connection
+            ->commitSchema(
+                [
+                    'name' => self::NAME,
+                    'schema' => [
+                        'definition' => 'test',
+                        'type' => 'AVRO',
+                    ],
+                ]
+            )
+            ->shouldBeCalledOnce()
+            ->willReturn(['foo' => 'bar']);
+
+        $this->schema->___setProperty('connection', $this->connection->reveal());
+
+        $this->assertEquals('bar', $this->schema->commit('test', 'AVRO')['foo']);
+    }
+
+    public function testDeleteRevision()
+    {
+        $this->connection
+            ->deleteRevision(['name' => self::NAME . '@1234567'])
+            ->shouldBeCalledOnce()
+            ->willReturn(['foo' => 'bar']);
+
+        $this->schema->___setProperty('connection', $this->connection->reveal());
+
+        $this->assertEquals('bar', $this->schema->deleteRevision('1234567')['foo']);
+    }
 }


### PR DESCRIPTION
This pull request addresses a critical gap in the existing functionality of the Google Library in PHP by introducing support for managing schema revisions within Google Pub/Sub. Currently, this feature is missing, and this PR aims to rectify that by providing the ability to retrieve all revisions for a specific schema, as well as the capability to commit and delete these revisions.

**Key Changes:**

Schema Revision Retrieval: We've added a new method to the Google Library that allows users to retrieve all revisions associated with a particular schema. This enhancement makes it easier to track and manage schema changes over time.

Example Usage:

```php
$client = new PubSubClient();
$schema = $client->schema('schema_name');
$revisions = $schema->listRevisions();

foreach ($revisions['schemas'] as $revision) {
    echo $revision['definition'];
}

```
Commit and Delete Revisions: To provide comprehensive schema management, we've introduced methods for committing and deleting schema revisions. These functions empower users to control their schema history effectively.

Example Usage (Committing a Revision):

```php
$client = new PubSubClient();
$schema = $client->schema('schema_name');
$definition = file_get_contents('path_to_your_schema_definition.json');
$revision = $schema->commit($definition, $typw);
```

```php
$client = new PubSubClient();
$schema = $client->schema('schema_name');
$revisions = $schema->deleteRevision('revision_id);
```

**Benefits:**

Improved Schema Management: Users can now effortlessly access, commit, and delete schema revisions, enhancing the overall schema management experience.
Comprehensive Control: This addition provides a holistic solution for handling schema revisions within Google Pub/Sub, ensuring better version control and traceability.
We believe that this PR will significantly improve the functionality and usability of the Google Library in PHP, making it a more powerful tool for developers working with Google Pub/Sub schemas. Your feedback and review on this PR are highly appreciated.