### PR TITLE
fix: [PubSub] encode option

### DIFF
--- a/src/PubSubClient.php
+++ b/src/PubSubClient.php
@@ -196,6 +196,10 @@ class PubSubClient
             $config['universeDomain']
         );
 
+        if (isset($config['encode'])) {
+            $this->encode = (bool) $config['encode'];
+        }
+
         $this->projectId = $this->detectProjectId($config);
 
         $this->clientConfig = $config;


### PR DESCRIPTION
After we upgraded from v1 to v2, the `consume()` method is not longer returning the message data decoded.

Before, it was done by setting the `encode` option here:
https://github.com/googleapis/google-cloud-php-pubsub/blob/d95e3989f1bfe9a3d982df369a761ae3a9ad6aff/src/PubSubClient.php#L161-L167

It looks like the `encode` is never set, and there is no way to set it anymore.

I am not sure if this sis the correct fix for this issue.